### PR TITLE
Adding support to configure multiple lambdas at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Heroku-like experience with AWS Lambdas.
 $ lambdoku init <ARN-of-your-lambda-function>
 ```
 
-this allows you to omit the `-a` param for all commands below
+this allows you to omit the `-a` param for all commands below. 
 
+In theory you can pass multiple lambdas in command line to managed them all by once (but this can easily lead to mistakes)
 
 ### Simplified environment variables management (`heroku config`)
 


### PR DESCRIPTION
closes https://github.com/kubek2k/lambdoku/issues/11

not sure its perfect, and for some use cases hardly make any sense (for example adding the same downstream for multiple lambdas). On the other hand it doesn't disturb the normal operation, so I could live with that. Still its a subject to question if it makes sense in a long run.